### PR TITLE
Update swig_type_info for swig-4.2.0

### DIFF
--- a/copasi/bindings/common/downcast_common.cpp
+++ b/copasi/bindings/common/downcast_common.cpp
@@ -285,7 +285,7 @@ GetDowncastSwigTypeForCDataContainer(CDataContainer* container)
     }
   else if (dynamic_cast<ReportItemVector*>(container))
     {
-#ifdef SWIGPERL
+#if defined(SWIGPERL) || SWIG_VERSION >= 0x040200
       pInfo = SWIGTYPE_p_std__vectorT_CRegisteredCommonName_t;
 #else
       pInfo = SWIGTYPE_p_std__vectorT_CRegisteredCommonName_std__allocatorT_CRegisteredCommonName_t_t;
@@ -293,7 +293,7 @@ GetDowncastSwigTypeForCDataContainer(CDataContainer* container)
     }
   else if (dynamic_cast<ParameterVector*>(container))
     {
-#ifdef SWIGPERL
+#if defined(SWIGPERL) || SWIG_VERSION >= 0x040200
       pInfo = SWIGTYPE_p_std__vectorT_CCopasiParameter_p_t;
 #else
       pInfo = SWIGTYPE_p_std__vectorT_CCopasiParameter_p_std__allocatorT_CCopasiParameter_p_t_t;
@@ -301,7 +301,7 @@ GetDowncastSwigTypeForCDataContainer(CDataContainer* container)
     }
   else if (dynamic_cast<CFunctionStdVector*>(container))
     {
-#ifdef SWIGPERL
+#if defined(SWIGPERL) || SWIG_VERSION >= 0x040200
       pInfo = SWIGTYPE_p_std__vectorT_CFunction_p_t;
 #else
       pInfo = SWIGTYPE_p_std__vectorT_CFunction_p_std__allocatorT_CFunction_p_t_t;


### PR DESCRIPTION
swig-4.2.0 changed the mangling for templates with default parameters. This commit updates the swig_type_info names for swig-4.2.0, but keeps the code backwards compatible to work with older versions of SWIG.

Reported in issue swig/swig#2764